### PR TITLE
Patch rocpoints

### DIFF
--- a/roc.lua
+++ b/roc.lua
@@ -74,7 +74,7 @@ end
 function roc.points(responses, labels, neglabel, poslabel)
 
         -- default values for arguments
-        poslabel = poslabel or +1
+        poslabel = poslabel or 1
         neglabel = neglabel or -1
 
 	-- assertions about the data format expected

--- a/roc.lua
+++ b/roc.lua
@@ -90,7 +90,6 @@ function roc.points(responses, labels, neglabel, poslabel)
 	local nsamples = npositives + nnegatives
 
 	assert(nsamples == responses:size()[1], "labels should contain only " .. neglabel .. " or " .. poslabel .. " values")
-	assert(nsamples == weights:size()[1],   "weights should have the same length as respones and labels")
 
 	local splits = roc.splits(responses, labels, neglabel, poslabel)
 


### PR DESCRIPTION
Fixed two fatal errors in `roc.points`:

- Replace `+1` with `1` as the former is not a valid integer, and
  resulted in the following error on `require`:
  `.../torch/install/share/lua/5.1/metrics/roc.lua:77: unexpected
  symbol near '+'`

- Remove line that was attempting to access `weights` which is not
  defined anywhere.

The package builds and `test/test.lua` runs without errors.